### PR TITLE
python-decouple 3.8 📦❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-decouple" %}
-{% set version = "3.7" %}
+{% set version = "3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,21 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e88a8d6bdf3b07d471a854099e455e20a6fa7a4d6ecf8631b250e3db654336e6
+  sha256: ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -v
+  script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
 
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,9 +32,9 @@ test:
     - pip
 
 about:
-  home: https://github.com/henriquebastos/python-decouple/
-  doc_url: https://github.com/henriquebastos/python-decouple/blob/master/README.rst
-  dev_url: https://github.com/henriquebastos/python-decouple/
+  home: https://github.com/HBNetwork/python-decouple
+  doc_url: https://github.com/HBNetwork/python-decouple/blob/master/README.rst
+  dev_url: https://github.com/HBNetwork/python-decouple
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
python-decouple 3.8 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4154](https://anaconda.atlassian.net/browse/PKG-4154) 
- [Upstream repository](https://github.com/HBNetwork/python-decouple/tree/v3.8)
- [Upstream changelog/diff](https://github.com/HBNetwork/python-decouple/compare/v3.7...v3.8)

### Explanation of changes:

- updated version # and SHA
- added script flag


[PKG-4154]: https://anaconda.atlassian.net/browse/PKG-4154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ