### PR TITLE
python-decouple 3.8 (py313 rebuild) :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
 
 requirements:


### PR DESCRIPTION
python-decouple 3.8 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8043]
- dev_url:        https://github.com/HBNetwork/python-decouple/tree/v3.8
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- rebuild for py313


[PKG-8043]: https://anaconda.atlassian.net/browse/PKG-8043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ